### PR TITLE
Fixes interaction between multi-file patches and JPath queries.

### DIFF
--- a/resources/modinfo.json
+++ b/resources/modinfo.json
@@ -2,7 +2,7 @@
   "type": "Code",
   "name": "Patch Wars",
   "modid": "patchwars",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Enhanced JSON patching",
   "website": "https://github.com/PJ-Mog/VSMod-PatchWars",
   "authors": [ "JapanHasRice" ],

--- a/src/JsonPatchExtended.cs
+++ b/src/JsonPatchExtended.cs
@@ -13,5 +13,24 @@ namespace PatchWars {
     public override string ToString() {
       return JsonConvert.SerializeObject(this);
     }
+
+    public JsonPatchExtended ShallowClone() {
+      return new JsonPatchExtended {
+        Op = this.Op,
+        File = this.File,
+        FromPath = this.FromPath,
+        Path = this.Path,
+        DependsOn = this.DependsOn,
+        Enabled = this.Enabled,
+        Side = this.Side,
+        Condition = this.Condition,
+        Value = this.Value,
+
+        PathAppend = this.PathAppend,
+        PatchMultiple = this.PatchMultiple,
+        SourceFileForLogging = this.SourceFileForLogging,
+        IndexForLogging = this.IndexForLogging
+      };
+    }
   }
 }


### PR DESCRIPTION
The JPath will now correctly parse for paths in each file instead of only the first.

Logging improvements:
A JPath query which finds 1 path will also be logged to debug instead of only queries which find more than 1. Separates paths discovered by JPath onto new lines for readability. Includes targeted file in many more log messages for clarity. Adjusted some log messages to match the pattern of the rest.